### PR TITLE
employ marking node feature to track the netlist without double checking

### DIFF
--- a/ODIN_II/SRC/include/odin_types.h
+++ b/ODIN_II/SRC/include/odin_types.h
@@ -57,6 +57,9 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 /* unique numbers to mark the nodes as we DFS traverse the netlist */
 #define PARTIAL_MAP_TRAVERSE_VALUE 10
+// MEHRSHAD //
+#define PARTIAL_MAP_TRAVERSE_VALUE_GA_ADDERS 11
+// MEHRSHAD //
 #define OUTPUT_TRAVERSE_VALUE 12
 #define COUNT_NODES 14 /* NOTE that you can't call countnodes one after the other or the mark will be incorrect */
 #define COMBO_LOOP 15
@@ -499,6 +502,10 @@ struct npin_t
 
 	edge_type_e sensitivity;
 
+	// MEHRSHAD //
+	short traverse_visited; // a way to mark if we've visited yet
+	// MEHRSHAD //
+
 	////////////////////
 	// For simulation
 	std::shared_ptr<AtomicBuffer> values;
@@ -524,6 +531,10 @@ struct nnet_t
 
 	short unique_net_data_id;
 	void *net_data;
+
+	// MEHRSHAD //
+	short traverse_visited; // a way to mark if we've visited yet
+	// MEHRSHAD //
 
 	/////////////////////
 	// For simulation

--- a/ODIN_II/SRC/include/partial_map.h
+++ b/ODIN_II/SRC/include/partial_map.h
@@ -55,7 +55,7 @@ void partial_map_adders_GA_top(netlist_t *netlist);
 void partial_map_adders(/*short traverse_number,*/ netlist_t *netlist);
 void destroy_adders();
 void destroy_adder_cloud (adder_t *adder);
-void recursive_save_pointers (adder_t *adder, nnode_t * node);
+void recursive_save_pointers (adder_t *adder, nnode_t * node, short mark);
 npin_t** make_copy_of_pins (npin_t **copy, long copy_size);
 adder_t *create_empty_adder (adder_t *previous_adder);
 generation_t* create_generation (generation_t *previous_generation, int generation_counter);

--- a/ODIN_II/SRC/partial_map.cpp
+++ b/ODIN_II/SRC/partial_map.cpp
@@ -1327,7 +1327,7 @@ void destroy_adder_cloud (adder_t *adder)
 	num_cloud_nodes = 0;
 
 	for (int i=0; i<adder->output->count; i++)
-		recursive_save_pointers (adder, adder->output->pins[i]->node);
+		recursive_save_pointers (adder, adder->output->pins[i]->node, PARTIAL_MAP_TRAVERSE_VALUE_GA_ADDERS);
 
 	// Free all pointers related to the cloud
 	while (num_cloud_pins != 0)
@@ -1357,30 +1357,45 @@ void destroy_adder_cloud (adder_t *adder)
 * and nodes related to the cloud which was created in partial
 * map for add function
 *----------------------------------------------------------*/
-void recursive_save_pointers (adder_t *adder, nnode_t * node)
+void recursive_save_pointers (adder_t *adder, nnode_t * node, short mark)
 {
+
+	// if the node has been visited before then the function should return
+	if ( node->traverse_visited ==  mark )
+		return;
+
 	cloud_nodes_list = (nnode_t**) vtr::realloc (cloud_nodes_list, sizeof(nnode_t *)*(num_cloud_nodes+1));
 	cloud_nodes_list[num_cloud_nodes] = node;
+	node->traverse_visited = mark;
 	num_cloud_nodes++;
 
 	for (int i=0; i<node->num_input_pins; i++)
 	{
-		cloud_pins_list = (npin_t **) vtr::realloc (cloud_pins_list, sizeof(npin_t *)*(num_cloud_pins+1));
-		cloud_pins_list[num_cloud_pins] = node->input_pins[i];
-		num_cloud_pins++;
+		if ( node->input_pins[i]->traverse_visited != mark ) {	
+			cloud_pins_list = (npin_t **) vtr::realloc (cloud_pins_list, sizeof(npin_t *)*(num_cloud_pins+1));
+			cloud_pins_list[num_cloud_pins] = node->input_pins[i];
+			node->input_pins[i]->traverse_visited = mark;
+			num_cloud_pins++;
+		}
 
-		cloud_nets_list = (nnet_t **) vtr::realloc(cloud_nets_list, sizeof(nnet_t *)*(num_cloud_nets+1));
-		cloud_nets_list[num_cloud_nets] = node->input_pins[i]->net;
-		num_cloud_nets++;
+		if ( node->input_pins[i]->net->traverse_visited != mark ) {	
+			cloud_nets_list = (nnet_t **) vtr::realloc(cloud_nets_list, sizeof(nnet_t *)*(num_cloud_nets+1));
+			cloud_nets_list[num_cloud_nets] = node->input_pins[i]->net;
+			node->input_pins[i]->net->traverse_visited = mark;
+			num_cloud_nets++;
+		}
 
-		cloud_pins_list = (npin_t **) vtr::realloc (cloud_pins_list, sizeof(npin_t *)*(num_cloud_pins+1));
-		for ( int j=0; j<adder->input->count; j++ )
-			if ( node->input_pins[i]->net->driver_pin == adder->input->pins[j]->net->driver_pin )
-				return;
-		cloud_pins_list[num_cloud_pins] = node->input_pins[i]->net->driver_pin;
-		num_cloud_pins++;
+		if ( node->input_pins[i]->net->driver_pin->traverse_visited != mark ) {
+			cloud_pins_list = (npin_t **) vtr::realloc (cloud_pins_list, sizeof(npin_t *)*(num_cloud_pins+1));
+			for ( int j=0; j<adder->input->count; j++ )
+				if ( node->input_pins[i]->net->driver_pin == adder->input->pins[j]->net->driver_pin )
+					return;
+			cloud_pins_list[num_cloud_pins] = node->input_pins[i]->net->driver_pin;
+			node->input_pins[i]->net->driver_pin->traverse_visited = mark;
+			num_cloud_pins++;
+		}
 
-		recursive_save_pointers (adder, node->input_pins[i]->net->driver_pin->node);
+		recursive_save_pointers (adder, node->input_pins[i]->net->driver_pin->node, mark);
 	}
 	
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
set the value of travesed_visited for every pin, net, and node to avoid double tracing them during destroying adder cloud.
